### PR TITLE
feat: make defaultLatexFontFamilies public and auto-resolve defaults

### DIFF
--- a/latex-renderer/src/commonMain/kotlin/com/hrm/latex/renderer/Latex.kt
+++ b/latex-renderer/src/commonMain/kotlin/com/hrm/latex/renderer/Latex.kt
@@ -44,6 +44,7 @@ import com.hrm.latex.renderer.layout.measureGroup
 import com.hrm.latex.renderer.model.LatexConfig
 import com.hrm.latex.renderer.model.LineBreakingConfig
 import com.hrm.latex.renderer.model.RenderContext
+import com.hrm.latex.renderer.model.defaultLatexFontFamilies
 import com.hrm.latex.renderer.model.toContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -79,8 +80,15 @@ fun Latex(
         config.backgroundColor
     }
 
+    // resolve default font families when not explicitly provided
+    val resolvedConfig = if (config.fontFamilies == null) {
+        config.copy(fontFamilies = defaultLatexFontFamilies())
+    } else {
+        config
+    }
+
     // 构建初始渲染上下文
-    val context = config.toContext(isDarkTheme)
+    val context = resolvedConfig.toContext(isDarkTheme)
 
     // 复用解析器实例以支持真正的增量解析
     val parser = remember { IncrementalLatexParser() }

--- a/latex-renderer/src/commonMain/kotlin/com/hrm/latex/renderer/model/LatexFontFamily.kt
+++ b/latex-renderer/src/commonMain/kotlin/com/hrm/latex/renderer/model/LatexFontFamily.kt
@@ -237,7 +237,7 @@ data class LatexFontFamilies(
  * - MicroTeX 的实际配置也是使用完整版字体
  */
 @Composable
-internal fun defaultLatexFontFamilies(): LatexFontFamilies {
+fun defaultLatexFontFamilies(): LatexFontFamilies {
     // === 文本字体：使用完整版 ===
     // cmr10 - Computer Modern Roman，包含完整拉丁字母表
     val roman = FontFamily(


### PR DESCRIPTION
## Summary
- Make `defaultLatexFontFamilies()` public (was `internal`) so users can access default font families
- `Latex` composable now auto-populates default font families when `config.fontFamilies` is null
- Users can now customize fonts via `defaultLatexFontFamilies().copy(roman = customFont)`

Fixes #9