### PR TITLE
fix: 修复构建错误

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,16 +7,16 @@ androidx-activity = "1.12.4"
 androidx-appcompat = "1.7.1"
 androidx-core = "1.17.0"
 androidx-espresso = "3.7.0"
-androidx-lifecycle = "2.9.6"
+androidx-lifecycle = "2.10.0"
 androidx-testExt = "1.3.0"
 composeHotReload = "1.0.0"
 composeMultiplatform = "1.10.1"
 composeMaterial3 = "1.9.0"
 junit = "4.13.2"
-kotlin = "2.3.0"
+kotlin = "2.3.10"
 kotlinx-coroutines = "1.10.2"
 latex = "1.2.1"
-androidx-navigationevent = "1.1.0-alpha01"
+androidx-navigationevent = "1.0.1"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -29,10 +29,10 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
-androidx-navigationevent = { module = "androidx.navigationevent:navigationevent-compose", version.ref = "androidx-navigationevent" }
+androidx-navigationevent = { module = "org.jetbrains.androidx.navigationevent:navigationevent-compose", version.ref = "androidx-navigationevent" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
-androidx-compose-uiTooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "composeMultiplatform" }
+androidx-compose-uiTooling = { module = "androidx.compose.ui:ui-tooling", version = "1.10.1" }
 latex-base = { module = "io.github.huarangmeng:latex-base", version.ref = "latex" }
 latex-parser = { module = "io.github.huarangmeng:latex-parser", version.ref = "latex" }
 latex-renderer = { module = "io.github.huarangmeng:latex-renderer", version.ref = "latex" }
@@ -43,6 +43,7 @@ compose-material3 = { module = "org.jetbrains.compose.material3:material3", vers
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
+compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "composeMultiplatform" }
 
 [bundles]
 latex = ["latex-base", "latex-parser", "latex-renderer"]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/latex-preview/build.gradle.kts
+++ b/latex-preview/build.gradle.kts
@@ -65,3 +65,7 @@ kotlin {
         }
     }
 }
+
+dependencies {
+    androidRuntimeClasspath(libs.compose.ui.tooling)
+}

--- a/latex-preview/src/commonMain/kotlin/com/hrm/latex/preview/BasicLatexPreview.kt
+++ b/latex-preview/src/commonMain/kotlin/com/hrm/latex/preview/BasicLatexPreview.kt
@@ -907,7 +907,7 @@ val basicLatexPreviewGroups = listOf(
 
 @Preview
 @Composable
-fun BasicLatexPreview(onBack: () -> Unit) {
+fun BasicLatexPreview(onBack: () -> Unit = {}) {
     PreviewCategoryScreen(
         title = "基础 LaTeX",
         groups = basicLatexPreviewGroups,


### PR DESCRIPTION
- 更新Kotlin, Lifecycle, Gradle 等版本
- `androidx.navigationevent:navigationevent-compose` -> `org.jetbrains.androidx.navigationevent:navigationevent-compose`，否则除Android外平台运行时会报错`LocalHostDefaultProvider` not provided
- preview模块添加`androidRuntimeClasspath`，否则无法正常预览