### PR TITLE
Apply minSdk to base, parse, and preview

### DIFF
--- a/latex-base/build.gradle.kts
+++ b/latex-base/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
     androidLibrary {
         namespace = "com.hrm.latex.base"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
+        minSdk = libs.versions.android.minSdk.get().toInt()
 
         withJava()
         withHostTestBuilder {}.configure {}

--- a/latex-parser/build.gradle.kts
+++ b/latex-parser/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
     androidLibrary {
         namespace = "com.hrm.latex.parser"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
+        minSdk = libs.versions.android.minSdk.get().toInt()
 
         withJava()
         withHostTestBuilder {}.configure {}

--- a/latex-preview/build.gradle.kts
+++ b/latex-preview/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
     androidLibrary {
         namespace = "com.hrm.latex.preview"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
+        minSdk = libs.versions.android.minSdk.get().toInt()
         androidResources.enable = true
 
         withJava()


### PR DESCRIPTION
This avoids the automatic inclusion of READ_PHONE_STATE and READ_EXTERNAL_STORAGE permissions.

In another note, it's possible to change the minSdk to match compose's minSdk (23)