### PR TITLE
feat(parser): support LaTeX font size commands and fix declarations parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ A high-performance LaTeX mathematical formula parsing and rendering library deve
 </details>
 
 <details>
+<summary><b>Font Sizes (10)</b></summary>
+
+`\tiny`, `\scriptsize`, `\footnotesize`, `\small`, `\normalsize`, `\large`, `\Large`, `\LARGE`, `\huge`, `\Huge`
+</details>
+
+<details>
 <summary><b>Math Mode Switching</b></summary>
 
 `\displaystyle`, `\textstyle`, `\scriptstyle`, `\scriptscriptstyle`, `$...$` (inline), `$$...$$` (display)

--- a/README_zh.md
+++ b/README_zh.md
@@ -89,6 +89,12 @@
 </details>
 
 <details>
+<summary><b>字号（10）</b></summary>
+
+`\tiny`, `\scriptsize`, `\footnotesize`, `\small`, `\normalsize`, `\large`, `\Large`, `\LARGE`, `\huge`, `\Huge`
+</details>
+
+<details>
 <summary><b>数学模式切换</b></summary>
 
 `\displaystyle`, `\textstyle`, `\scriptstyle`, `\scriptscriptstyle`, `$...$`（行内）, `$$...$$`（展示）

--- a/latex-parser/PARSER_COVERAGE_ANALYSIS.md
+++ b/latex-parser/PARSER_COVERAGE_ANALYSIS.md
@@ -271,11 +271,13 @@
 - ✅ `\symit{x}` Unicode 数学斜体
 - ✅ `\symsf{x}` Unicode 数学无衬线体
 - ✅ `\symrm{x}` Unicode 数学罗马体
+- ✅ `\tiny` / `\scriptsize` / `\footnotesize` / `\small` / `\normalsize`
+- ✅ `\large` / `\Large` / `\LARGE` / `\huge` / `\Huge`
 
 ### ❌ 缺失
 - 无
 
-**覆盖率**: 17/17 (100%) ✅
+**覆盖率**: 27/27 (100%) ✅
 
 ---
 

--- a/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/LatexParser.kt
+++ b/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/LatexParser.kt
@@ -118,7 +118,7 @@ internal class ParseSession(
         }
 
         val document = LatexNode.Document(
-            applyStyleDeclarations(children),
+            normalizeStyleDeclarations(children),
             sourceRange = SourceRange(0, inputLength)
         )
         HLog.d(TAG) { "解析成功，生成 ${children.size} 个节点, 诊断: ${diagnostics.size} 条" }
@@ -247,7 +247,7 @@ internal class ParseSession(
         if (!tokenStream.isEOF()) {
             tokenStream.expect("}")
         }
-        return LatexNode.Group(applyStyleDeclarations(children), sourceRange = tokenStream.rangeFrom(startOffset))
+        return LatexNode.Group(normalizeStyleDeclarations(children), sourceRange = tokenStream.rangeFrom(startOffset))
     }
 
     override fun parseArgument(): LatexNode? {
@@ -279,7 +279,7 @@ internal class ParseSession(
         }
 
         val range = tokenStream.rangeFrom(startOffset)
-        val normalizedChildren = applyStyleDeclarations(children)
+        val normalizedChildren = normalizeStyleDeclarations(children)
         return if (count == 2) {
             LatexNode.DisplayMath(normalizedChildren, sourceRange = range)
         } else {
@@ -294,7 +294,7 @@ internal class ParseSession(
         }
     }
 
-    private fun applyStyleDeclarations(nodes: List<LatexNode>): List<LatexNode> {
+    override fun normalizeStyleDeclarations(nodes: List<LatexNode>): List<LatexNode> {
         if (nodes.none { it.isStyleDeclaration() }) return nodes
         val result = mutableListOf<LatexNode>()
         val activeDeclarations = mutableListOf<LatexNode>()

--- a/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/LatexParser.kt
+++ b/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/LatexParser.kt
@@ -118,7 +118,7 @@ internal class ParseSession(
         }
 
         val document = LatexNode.Document(
-            applyFontSizeDeclarations(children),
+            applyStyleDeclarations(children),
             sourceRange = SourceRange(0, inputLength)
         )
         HLog.d(TAG) { "解析成功，生成 ${children.size} 个节点, 诊断: ${diagnostics.size} 条" }
@@ -247,7 +247,7 @@ internal class ParseSession(
         if (!tokenStream.isEOF()) {
             tokenStream.expect("}")
         }
-        return LatexNode.Group(applyFontSizeDeclarations(children), sourceRange = tokenStream.rangeFrom(startOffset))
+        return LatexNode.Group(applyStyleDeclarations(children), sourceRange = tokenStream.rangeFrom(startOffset))
     }
 
     override fun parseArgument(): LatexNode? {
@@ -279,7 +279,7 @@ internal class ParseSession(
         }
 
         val range = tokenStream.rangeFrom(startOffset)
-        val normalizedChildren = applyFontSizeDeclarations(children)
+        val normalizedChildren = applyStyleDeclarations(children)
         return if (count == 2) {
             LatexNode.DisplayMath(normalizedChildren, sourceRange = range)
         } else {
@@ -294,31 +294,90 @@ internal class ParseSession(
         }
     }
 
-    private fun applyFontSizeDeclarations(nodes: List<LatexNode>): List<LatexNode> {
-        if (nodes.none { it is LatexNode.FontSize && it.content.isEmpty() }) return nodes
-
+    private fun applyStyleDeclarations(nodes: List<LatexNode>): List<LatexNode> {
+        if (nodes.none { it.isStyleDeclaration() }) return nodes
         val result = mutableListOf<LatexNode>()
+        val activeDeclarations = mutableListOf<LatexNode>()
+        val segment = mutableListOf<LatexNode>()
+
+        fun flushSegment() {
+            if (segment.isEmpty()) return
+            if (activeDeclarations.isEmpty()) {
+                result.addAll(segment)
+            } else {
+                result.add(wrapWithDeclarations(segment.toList(), activeDeclarations))
+            }
+            segment.clear()
+        }
+
         var index = 0
         while (index < nodes.size) {
             val node = nodes[index]
-            if (node is LatexNode.FontSize && node.content.isEmpty()) {
-                val content = mutableListOf<LatexNode>()
+            if (node.isStyleDeclaration()) {
+                flushSegment()
+                updateActiveDeclaration(activeDeclarations, node)
                 index++
                 while (index < nodes.size && nodes[index] is LatexNode.Space) {
                     index++
                 }
-                while (index < nodes.size) {
-                    val next = nodes[index]
-                    if (next is LatexNode.FontSize && next.content.isEmpty()) break
-                    content.add(next)
-                    index++
-                }
-                result.add(node.copy(content = content))
             } else {
-                result.add(node)
+                segment.add(node)
                 index++
             }
         }
+        flushSegment()
         return result
+    }
+
+    private fun LatexNode.isStyleDeclaration(): Boolean = when (this) {
+        is LatexNode.Style -> content.isEmpty()
+        is LatexNode.MathStyle -> content.isEmpty()
+        is LatexNode.FontSize -> content.isEmpty()
+        else -> false
+    }
+
+    private fun updateActiveDeclaration(activeDeclarations: MutableList<LatexNode>, declaration: LatexNode) {
+        val existingIndex = activeDeclarations.indexOfLast { existing ->
+            (existing is LatexNode.Style && declaration is LatexNode.Style) ||
+                (existing is LatexNode.MathStyle && declaration is LatexNode.MathStyle) ||
+                (existing is LatexNode.FontSize && declaration is LatexNode.FontSize)
+        }
+        if (existingIndex >= 0) {
+            activeDeclarations[existingIndex] = declaration
+        } else {
+            activeDeclarations.add(declaration)
+        }
+    }
+
+    private fun wrapWithDeclarations(content: List<LatexNode>, declarations: List<LatexNode>): LatexNode {
+        var node: LatexNode = if (content.size == 1) content[0] else LatexNode.Group(content, mergeRange(content))
+        for (declaration in declarations.asReversed()) {
+            node = when (declaration) {
+                is LatexNode.Style -> declaration.copy(
+                    content = listOf(node),
+                    sourceRange = declaration.sourceRange.mergeWith(node.sourceRange)
+                )
+                is LatexNode.MathStyle -> declaration.copy(
+                    content = listOf(node),
+                    sourceRange = declaration.sourceRange.mergeWith(node.sourceRange)
+                )
+                is LatexNode.FontSize -> declaration.copy(
+                    content = listOf(node),
+                    sourceRange = declaration.sourceRange.mergeWith(node.sourceRange)
+                )
+                else -> node
+            }
+        }
+        return node
+    }
+
+    private fun mergeRange(nodes: List<LatexNode>): SourceRange? {
+        return nodes.mapNotNull { it.sourceRange }.reduceOrNull { acc, range -> acc.merge(range) }
+    }
+
+    private fun SourceRange?.mergeWith(other: SourceRange?): SourceRange? = when {
+        this != null && other != null -> merge(other)
+        this != null -> this
+        else -> other
     }
 }

--- a/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/LatexParser.kt
+++ b/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/LatexParser.kt
@@ -118,7 +118,7 @@ internal class ParseSession(
         }
 
         val document = LatexNode.Document(
-            children,
+            applyFontSizeDeclarations(children),
             sourceRange = SourceRange(0, inputLength)
         )
         HLog.d(TAG) { "解析成功，生成 ${children.size} 个节点, 诊断: ${diagnostics.size} 条" }
@@ -247,7 +247,7 @@ internal class ParseSession(
         if (!tokenStream.isEOF()) {
             tokenStream.expect("}")
         }
-        return LatexNode.Group(children, sourceRange = tokenStream.rangeFrom(startOffset))
+        return LatexNode.Group(applyFontSizeDeclarations(children), sourceRange = tokenStream.rangeFrom(startOffset))
     }
 
     override fun parseArgument(): LatexNode? {
@@ -279,10 +279,11 @@ internal class ParseSession(
         }
 
         val range = tokenStream.rangeFrom(startOffset)
+        val normalizedChildren = applyFontSizeDeclarations(children)
         return if (count == 2) {
-            LatexNode.DisplayMath(children, sourceRange = range)
+            LatexNode.DisplayMath(normalizedChildren, sourceRange = range)
         } else {
-            LatexNode.InlineMath(children, sourceRange = range)
+            LatexNode.InlineMath(normalizedChildren, sourceRange = range)
         }
     }
 
@@ -291,5 +292,33 @@ internal class ParseSession(
             is LatexToken.LeftBrace -> parseGroup()
             else -> parseFactor() ?: LatexNode.Text("")
         }
+    }
+
+    private fun applyFontSizeDeclarations(nodes: List<LatexNode>): List<LatexNode> {
+        if (nodes.none { it is LatexNode.FontSize && it.content.isEmpty() }) return nodes
+
+        val result = mutableListOf<LatexNode>()
+        var index = 0
+        while (index < nodes.size) {
+            val node = nodes[index]
+            if (node is LatexNode.FontSize && node.content.isEmpty()) {
+                val content = mutableListOf<LatexNode>()
+                index++
+                while (index < nodes.size && nodes[index] is LatexNode.Space) {
+                    index++
+                }
+                while (index < nodes.size) {
+                    val next = nodes[index]
+                    if (next is LatexNode.FontSize && next.content.isEmpty()) break
+                    content.add(next)
+                    index++
+                }
+                result.add(node.copy(content = content))
+            } else {
+                result.add(node)
+                index++
+            }
+        }
+        return result
     }
 }

--- a/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/component/EnvironmentParser.kt
+++ b/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/component/EnvironmentParser.kt
@@ -124,7 +124,7 @@ internal class EnvironmentParser(private val context: LatexParserContext) {
                 is LatexToken.EndEnvironment -> {
                     if (token.name == envName) {
                         if (currentCell.isNotEmpty()) {
-                            currentRow.add(LatexNode.Group(currentCell))
+                            currentRow.add(LatexNode.Group(context.normalizeStyleDeclarations(currentCell)))
                         }
                         if (currentRow.isNotEmpty()) {
                             rows.add(currentRow)
@@ -138,14 +138,14 @@ internal class EnvironmentParser(private val context: LatexParserContext) {
                 }
 
                 is LatexToken.Ampersand -> {
-                    currentRow.add(LatexNode.Group(currentCell))
+                    currentRow.add(LatexNode.Group(context.normalizeStyleDeclarations(currentCell)))
                     currentCell = mutableListOf()
                     tokenStream.advance()
                 }
 
                 is LatexToken.NewLine -> {
                     if (currentCell.isNotEmpty()) {
-                        currentRow.add(LatexNode.Group(currentCell))
+                        currentRow.add(LatexNode.Group(context.normalizeStyleDeclarations(currentCell)))
                     }
                     if (currentRow.isNotEmpty()) {
                         rows.add(currentRow)
@@ -161,7 +161,7 @@ internal class EnvironmentParser(private val context: LatexParserContext) {
                         if (handleSpecialNodes && (node is LatexNode.HLine || node is LatexNode.CLine)) {
                             // 先保存当前累积的内容
                             if (currentCell.isNotEmpty()) {
-                                currentRow.add(LatexNode.Group(currentCell))
+                                currentRow.add(LatexNode.Group(context.normalizeStyleDeclarations(currentCell)))
                                 currentCell = mutableListOf()
                             }
                             if (currentRow.isNotEmpty()) {
@@ -260,7 +260,7 @@ internal class EnvironmentParser(private val context: LatexParserContext) {
                 is LatexToken.EndEnvironment -> {
                     if (token.name == envName) {
                         if (currentLine.isNotEmpty()) {
-                            lines.add(LatexNode.Group(currentLine))
+                            lines.add(LatexNode.Group(context.normalizeStyleDeclarations(currentLine)))
                         }
                         tokenStream.advance()
                         break
@@ -271,7 +271,7 @@ internal class EnvironmentParser(private val context: LatexParserContext) {
 
                 is LatexToken.NewLine -> {
                     if (currentLine.isNotEmpty()) {
-                        lines.add(LatexNode.Group(currentLine))
+                        lines.add(LatexNode.Group(context.normalizeStyleDeclarations(currentLine)))
                     }
                     currentLine = mutableListOf()
                     tokenStream.advance()
@@ -320,7 +320,8 @@ internal class EnvironmentParser(private val context: LatexParserContext) {
                     if (token.name == envName) {
                         if (expression.isNotEmpty()) {
                             cases.add(
-                                LatexNode.Group(expression) to LatexNode.Group(condition)
+                                LatexNode.Group(context.normalizeStyleDeclarations(expression)) to
+                                    LatexNode.Group(context.normalizeStyleDeclarations(condition))
                             )
                         }
                         tokenStream.advance()
@@ -338,7 +339,8 @@ internal class EnvironmentParser(private val context: LatexParserContext) {
                 is LatexToken.NewLine -> {
                     if (expression.isNotEmpty()) {
                         cases.add(
-                            LatexNode.Group(expression) to LatexNode.Group(condition)
+                            LatexNode.Group(context.normalizeStyleDeclarations(expression)) to
+                                LatexNode.Group(context.normalizeStyleDeclarations(condition))
                         )
                     }
                     expression = mutableListOf()
@@ -408,7 +410,7 @@ internal class EnvironmentParser(private val context: LatexParserContext) {
             }
         }
 
-        return content
+        return context.normalizeStyleDeclarations(content)
     }
 
     /**
@@ -434,7 +436,8 @@ internal class EnvironmentParser(private val context: LatexParserContext) {
                 if (!tokenStream.isEOF()) {
                     tokenStream.advance() // consume ]
                 }
-                if (nodes.size == 1) nodes[0] else LatexNode.Group(nodes)
+                val normalizedNodes = context.normalizeStyleDeclarations(nodes)
+                if (normalizedNodes.size == 1) normalizedNodes[0] else LatexNode.Group(normalizedNodes)
             } else {
                 LatexNode.Text(customEnv.defaultArg)
             }
@@ -458,7 +461,7 @@ internal class EnvironmentParser(private val context: LatexParserContext) {
         val expandedEnd = replaceParameters(customEnv.endDef, args)
 
         // 组装：beginDef + body + endDef
-        val allContent = expandedBegin + bodyContent + expandedEnd
+        val allContent = context.normalizeStyleDeclarations(expandedBegin + bodyContent + expandedEnd)
         return LatexNode.Group(allContent)
     }
 

--- a/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/component/LatexParserContext.kt
+++ b/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/component/LatexParserContext.kt
@@ -76,4 +76,5 @@ internal interface LatexParserContext {
     fun parseFactor(): LatexNode?
     fun parseArgument(): LatexNode?
     fun parseGroup(): LatexNode.Group
+    fun normalizeStyleDeclarations(nodes: List<LatexNode>): List<LatexNode>
 }

--- a/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/component/handler/StyleHandlers.kt
+++ b/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/component/handler/StyleHandlers.kt
@@ -23,6 +23,7 @@
 package com.hrm.latex.parser.component.handler
 
 import com.hrm.latex.parser.model.LatexNode
+import com.hrm.latex.parser.tokenizer.LatexToken
 
 /**
  * 字体样式 & 数学模式切换命令
@@ -89,6 +90,30 @@ internal fun CommandRegistry.installStyleHandlers() {
                 if (content != null) listOf(content) else emptyList(),
                 mathStyleType
             )
+        }
+    }
+
+    val fontSizeMapping = mapOf(
+        "tiny" to LatexNode.FontSize.SizeType.TINY,
+        "scriptsize" to LatexNode.FontSize.SizeType.SCRIPT_SIZE,
+        "footnotesize" to LatexNode.FontSize.SizeType.FOOTNOTE_SIZE,
+        "small" to LatexNode.FontSize.SizeType.SMALL,
+        "normalsize" to LatexNode.FontSize.SizeType.NORMAL_SIZE,
+        "large" to LatexNode.FontSize.SizeType.LARGE,
+        "Large" to LatexNode.FontSize.SizeType.LARGE_2,
+        "LARGE" to LatexNode.FontSize.SizeType.LARGE_3,
+        "huge" to LatexNode.FontSize.SizeType.HUGE,
+        "Huge" to LatexNode.FontSize.SizeType.HUGE_2,
+    )
+
+    for ((cmd, sizeType) in fontSizeMapping) {
+        register(cmd) { _, ctx, stream ->
+            val content = if (stream.peek() is LatexToken.LeftBrace) {
+                listOfNotNull(ctx.parseArgument())
+            } else {
+                emptyList()
+            }
+            LatexNode.FontSize(content, sizeType)
         }
     }
 

--- a/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/component/handler/StyleHandlers.kt
+++ b/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/component/handler/StyleHandlers.kt
@@ -23,38 +23,28 @@
 package com.hrm.latex.parser.component.handler
 
 import com.hrm.latex.parser.model.LatexNode
-import com.hrm.latex.parser.tokenizer.LatexToken
 
 /**
  * 字体样式 & 数学模式切换命令
  */
 internal fun CommandRegistry.installStyleHandlers() {
     // 字体样式
-    val styleMapping = mapOf(
+    val styleCommandMapping = mapOf(
         "mathbf" to LatexNode.Style.StyleType.BOLD,
         "textbf" to LatexNode.Style.StyleType.BOLD,
-        "bf" to LatexNode.Style.StyleType.BOLD,
         "boldsymbol" to LatexNode.Style.StyleType.BOLD_SYMBOL,
         "bm" to LatexNode.Style.StyleType.BOLD_SYMBOL,
         "mathit" to LatexNode.Style.StyleType.ITALIC,
         "textit" to LatexNode.Style.StyleType.ITALIC,
-        "it" to LatexNode.Style.StyleType.ITALIC,
         "mathrm" to LatexNode.Style.StyleType.ROMAN,
         "textrm" to LatexNode.Style.StyleType.ROMAN,
-        "rm" to LatexNode.Style.StyleType.ROMAN,
         "mathsf" to LatexNode.Style.StyleType.SANS_SERIF,
         "textsf" to LatexNode.Style.StyleType.SANS_SERIF,
-        "sf" to LatexNode.Style.StyleType.SANS_SERIF,
         "mathtt" to LatexNode.Style.StyleType.MONOSPACE,
         "texttt" to LatexNode.Style.StyleType.MONOSPACE,
-        "tt" to LatexNode.Style.StyleType.MONOSPACE,
         "mathbb" to LatexNode.Style.StyleType.BLACKBOARD_BOLD,
         // AMSFonts legacy alias: \Bbb{R} / \Bbb R
         "Bbb" to LatexNode.Style.StyleType.BLACKBOARD_BOLD,
-        // Legacy font switches (common in older LaTeX documents)
-        "cal" to LatexNode.Style.StyleType.CALLIGRAPHIC,
-        "frak" to LatexNode.Style.StyleType.FRAKTUR,
-        "scr" to LatexNode.Style.StyleType.SCRIPT,
         "mathfrak" to LatexNode.Style.StyleType.FRAKTUR,
         "mathscr" to LatexNode.Style.StyleType.SCRIPT,
         "mathcal" to LatexNode.Style.StyleType.CALLIGRAPHIC,
@@ -65,13 +55,30 @@ internal fun CommandRegistry.installStyleHandlers() {
         "symrm" to LatexNode.Style.StyleType.ROMAN,
     )
 
-    for ((cmd, styleType) in styleMapping) {
+    for ((cmd, styleType) in styleCommandMapping) {
         register(cmd) { _, ctx, _ ->
             val content = ctx.parseArgument()
             LatexNode.Style(
                 if (content != null) listOf(content) else emptyList(),
                 styleType
             )
+        }
+    }
+
+    val styleDeclarationMapping = mapOf(
+        "bf" to LatexNode.Style.StyleType.BOLD,
+        "it" to LatexNode.Style.StyleType.ITALIC,
+        "rm" to LatexNode.Style.StyleType.ROMAN,
+        "sf" to LatexNode.Style.StyleType.SANS_SERIF,
+        "tt" to LatexNode.Style.StyleType.MONOSPACE,
+        "cal" to LatexNode.Style.StyleType.CALLIGRAPHIC,
+        "frak" to LatexNode.Style.StyleType.FRAKTUR,
+        "scr" to LatexNode.Style.StyleType.SCRIPT,
+    )
+
+    for ((cmd, styleType) in styleDeclarationMapping) {
+        register(cmd) { _, _, _ ->
+            LatexNode.Style(emptyList(), styleType)
         }
     }
 
@@ -84,12 +91,8 @@ internal fun CommandRegistry.installStyleHandlers() {
     )
 
     for ((cmd, mathStyleType) in mathStyleMapping) {
-        register(cmd) { _, ctx, _ ->
-            val content = ctx.parseArgument()
-            LatexNode.MathStyle(
-                if (content != null) listOf(content) else emptyList(),
-                mathStyleType
-            )
+        register(cmd) { _, _, _ ->
+            LatexNode.MathStyle(emptyList(), mathStyleType)
         }
     }
 
@@ -107,13 +110,8 @@ internal fun CommandRegistry.installStyleHandlers() {
     )
 
     for ((cmd, sizeType) in fontSizeMapping) {
-        register(cmd) { _, ctx, stream ->
-            val content = if (stream.peek() is LatexToken.LeftBrace) {
-                listOfNotNull(ctx.parseArgument())
-            } else {
-                emptyList()
-            }
-            LatexNode.FontSize(content, sizeType)
+        register(cmd) { _, _, _ ->
+            LatexNode.FontSize(emptyList(), sizeType)
         }
     }
 

--- a/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/model/LatexNode.kt
+++ b/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/model/LatexNode.kt
@@ -536,6 +536,28 @@ sealed class LatexNode {
     }
 
     /**
+     * 字号节点
+     *
+     * @property content 内容
+     * @property sizeType 字号类型
+     */
+    data class FontSize(
+        val content: List<LatexNode>,
+        val sizeType: SizeType,
+        override val sourceRange: SourceRange? = null
+    ) : LatexNode() {
+        enum class SizeType {
+            TINY, SCRIPT_SIZE, FOOTNOTE_SIZE, SMALL, NORMAL_SIZE,
+            LARGE, LARGE_2, LARGE_3, HUGE, HUGE_2
+        }
+
+        override fun children() = content
+        override fun withSourceRange(range: SourceRange) = copy(sourceRange = range)
+        override fun withChildren(newChildren: List<LatexNode>) = copy(content = newChildren)
+        override fun <T> accept(visitor: LatexVisitor<T>) = visitor.visitFontSize(this)
+    }
+
+    /**
      * 大型运算符（求和、积分、乘积等）
      */
     data class BigOperator(

--- a/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/util/LatexPrinter.kt
+++ b/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/util/LatexPrinter.kt
@@ -58,6 +58,21 @@ class LatexPrinter : BaseLatexVisitor<String>() {
         output.append("Text('${node.content}')")
         return ""
     }
+
+    override fun visitFontSize(node: LatexNode.FontSize): String {
+        output.append("FontSize(${node.sizeType})")
+        if (node.content.isNotEmpty()) {
+            output.append("\n")
+            indent++
+            node.content.forEach {
+                printIndent()
+                visit(it)
+                output.append("\n")
+            }
+            indent--
+        }
+        return ""
+    }
     
     override fun visitFraction(node: LatexNode.Fraction): String {
         output.append("Fraction")

--- a/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/visitor/AccessibilityVisitor.kt
+++ b/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/visitor/AccessibilityVisitor.kt
@@ -224,6 +224,10 @@ class AccessibilityVisitor : BaseLatexVisitor<String>() {
         return node.content.joinToString(" ") { visit(it) }.collapseSpaces()
     }
 
+    override fun visitFontSize(node: LatexNode.FontSize): String {
+        return node.content.joinToString(" ") { visit(it) }.collapseSpaces()
+    }
+
     override fun visitBigOperator(node: LatexNode.BigOperator): String {
         val op = bigOperatorName(node.operator)
         val sub = node.subscript?.let { "from ${visit(it)}" }

--- a/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/visitor/LatexVisitor.kt
+++ b/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/visitor/LatexVisitor.kt
@@ -54,6 +54,7 @@ interface LatexVisitor<T> {
     fun visitStyle(node: LatexNode.Style): T
     fun visitColor(node: LatexNode.Color): T
     fun visitMathStyle(node: LatexNode.MathStyle): T
+    fun visitFontSize(node: LatexNode.FontSize): T
     fun visitBigOperator(node: LatexNode.BigOperator): T
     fun visitAligned(node: LatexNode.Aligned): T
     fun visitCases(node: LatexNode.Cases): T
@@ -214,6 +215,11 @@ abstract class BaseLatexVisitor<T> : LatexVisitor<T> {
     }
     
     override fun visitMathStyle(node: LatexNode.MathStyle): T {
+        node.content.forEach { visit(it) }
+        return defaultVisit(node)
+    }
+
+    override fun visitFontSize(node: LatexNode.FontSize): T {
         node.content.forEach { visit(it) }
         return defaultVisit(node)
     }
@@ -478,6 +484,7 @@ abstract class SimpleLatexVisitor<T> : LatexVisitor<T> {
     override fun visitStyle(node: LatexNode.Style): T = visitChildren(node)
     override fun visitColor(node: LatexNode.Color): T = visitChildren(node)
     override fun visitMathStyle(node: LatexNode.MathStyle): T = visitChildren(node)
+    override fun visitFontSize(node: LatexNode.FontSize): T = visitChildren(node)
     override fun visitBigOperator(node: LatexNode.BigOperator): T = visitChildren(node)
     override fun visitAligned(node: LatexNode.Aligned): T = visitChildren(node)
     override fun visitCases(node: LatexNode.Cases): T = visitChildren(node)

--- a/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/visitor/MathMLVisitor.kt
+++ b/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/visitor/MathMLVisitor.kt
@@ -23,6 +23,7 @@
 package com.hrm.latex.parser.visitor
 
 import com.hrm.latex.parser.model.LatexNode
+import kotlin.math.round
 
 /**
  * LaTeX AST → MathML 转换访问者
@@ -52,6 +53,7 @@ import com.hrm.latex.parser.model.LatexNode
  * - `<mphantom>` 幻影
  */
 class MathMLVisitor : BaseLatexVisitor<String>() {
+    private var currentFontScale: Float = 1.0f
 
     companion object {
         /**
@@ -305,20 +307,38 @@ class MathMLVisitor : BaseLatexVisitor<String>() {
     }
 
     override fun visitFontSize(node: LatexNode.FontSize): String {
-        val content = node.content.joinToString("") { visit(it) }
-        val size = when (node.sizeType) {
-            LatexNode.FontSize.SizeType.TINY -> "50%"
-            LatexNode.FontSize.SizeType.SCRIPT_SIZE -> "70%"
-            LatexNode.FontSize.SizeType.FOOTNOTE_SIZE -> "80%"
-            LatexNode.FontSize.SizeType.SMALL -> "90%"
-            LatexNode.FontSize.SizeType.NORMAL_SIZE -> "100%"
-            LatexNode.FontSize.SizeType.LARGE -> "120%"
-            LatexNode.FontSize.SizeType.LARGE_2 -> "144%"
-            LatexNode.FontSize.SizeType.LARGE_3 -> "173%"
-            LatexNode.FontSize.SizeType.HUGE -> "207%"
-            LatexNode.FontSize.SizeType.HUGE_2 -> "249%"
+        val inheritedScale = currentFontScale
+        val targetScale = node.sizeType.scaleFactor()
+        currentFontScale = targetScale
+        val content = try {
+            node.content.joinToString("") { visit(it) }
+        } finally {
+            currentFontScale = inheritedScale
         }
+        val size = formatPercent(targetScale / inheritedScale)
         return "<mstyle mathsize=\"$size\">$content</mstyle>"
+    }
+
+    private fun LatexNode.FontSize.SizeType.scaleFactor(): Float = when (this) {
+        LatexNode.FontSize.SizeType.TINY -> 0.5f
+        LatexNode.FontSize.SizeType.SCRIPT_SIZE -> 0.7f
+        LatexNode.FontSize.SizeType.FOOTNOTE_SIZE -> 0.8f
+        LatexNode.FontSize.SizeType.SMALL -> 0.9f
+        LatexNode.FontSize.SizeType.NORMAL_SIZE -> 1.0f
+        LatexNode.FontSize.SizeType.LARGE -> 1.2f
+        LatexNode.FontSize.SizeType.LARGE_2 -> 1.44f
+        LatexNode.FontSize.SizeType.LARGE_3 -> 1.728f
+        LatexNode.FontSize.SizeType.HUGE -> 2.074f
+        LatexNode.FontSize.SizeType.HUGE_2 -> 2.488f
+    }
+
+    private fun formatPercent(scale: Float): String {
+        val percent = round(scale * 100_000f) / 1_000f
+        return if (percent % 1f == 0f) {
+            "${percent.toInt()}%"
+        } else {
+            "${percent.toString().trimEnd('0').trimEnd('.')}%"
+        }
     }
 
     override fun visitBigOperator(node: LatexNode.BigOperator): String {

--- a/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/visitor/MathMLVisitor.kt
+++ b/latex-parser/src/commonMain/kotlin/com/hrm/latex/parser/visitor/MathMLVisitor.kt
@@ -304,6 +304,23 @@ class MathMLVisitor : BaseLatexVisitor<String>() {
         return "<mstyle$display>$content</mstyle>"
     }
 
+    override fun visitFontSize(node: LatexNode.FontSize): String {
+        val content = node.content.joinToString("") { visit(it) }
+        val size = when (node.sizeType) {
+            LatexNode.FontSize.SizeType.TINY -> "50%"
+            LatexNode.FontSize.SizeType.SCRIPT_SIZE -> "70%"
+            LatexNode.FontSize.SizeType.FOOTNOTE_SIZE -> "80%"
+            LatexNode.FontSize.SizeType.SMALL -> "90%"
+            LatexNode.FontSize.SizeType.NORMAL_SIZE -> "100%"
+            LatexNode.FontSize.SizeType.LARGE -> "120%"
+            LatexNode.FontSize.SizeType.LARGE_2 -> "144%"
+            LatexNode.FontSize.SizeType.LARGE_3 -> "173%"
+            LatexNode.FontSize.SizeType.HUGE -> "207%"
+            LatexNode.FontSize.SizeType.HUGE_2 -> "249%"
+        }
+        return "<mstyle mathsize=\"$size\">$content</mstyle>"
+    }
+
     override fun visitBigOperator(node: LatexNode.BigOperator): String {
         val op = "<mo>${escapeXml(node.operator)}</mo>"
         val sub = node.subscript?.let { visit(it) }

--- a/latex-parser/src/commonTest/kotlin/com/hrm/latex/parser/ComplexStructureTest.kt
+++ b/latex-parser/src/commonTest/kotlin/com/hrm/latex/parser/ComplexStructureTest.kt
@@ -402,6 +402,16 @@ class ComplexStructureTest {
     }
 
     @Test
+    fun testCalAliasScopesToGroupContent() {
+        val doc = parser.parse("{\\cal A + B}")
+        val group = doc.children[0] as LatexNode.Group
+        val style = group.children[0] as LatexNode.Style
+        assertEquals(LatexNode.Style.StyleType.CALLIGRAPHIC, style.styleType)
+        assertTrue(style.content.isNotEmpty())
+        assertTrue(style.content.any { it is LatexNode.Group })
+    }
+
+    @Test
     fun testFrakAlias() {
         val doc = parser.parse("\\frak g")
         val style = doc.children[0] as LatexNode.Style

--- a/latex-parser/src/commonTest/kotlin/com/hrm/latex/parser/ComplexStructureTest.kt
+++ b/latex-parser/src/commonTest/kotlin/com/hrm/latex/parser/ComplexStructureTest.kt
@@ -412,6 +412,16 @@ class ComplexStructureTest {
     }
 
     @Test
+    fun testStyleDeclarationInEnvironmentContent() {
+        val doc = parser.parse("\\begin{equation}\\bf x\\end{equation}")
+        val env = doc.children[0] as LatexNode.Environment
+        val style = env.content[0] as LatexNode.Style
+
+        assertEquals(LatexNode.Style.StyleType.BOLD, style.styleType)
+        assertEquals("x", (style.content[0] as LatexNode.Text).content)
+    }
+
+    @Test
     fun testFrakAlias() {
         val doc = parser.parse("\\frak g")
         val style = doc.children[0] as LatexNode.Style

--- a/latex-parser/src/commonTest/kotlin/com/hrm/latex/parser/FontSizeTest.kt
+++ b/latex-parser/src/commonTest/kotlin/com/hrm/latex/parser/FontSizeTest.kt
@@ -102,4 +102,39 @@ class FontSizeTest {
         assertEquals(1, range.start)
         assertEquals(input.length - 1, range.end)
     }
+
+    @Test
+    fun testFontSizeDeclarationInEquationEnvironment() {
+        val doc = parser.parse("\\begin{equation}\\small x\\end{equation}")
+        val environment = assertIs<LatexNode.Environment>(doc.children[0])
+        val fontSize = assertIs<LatexNode.FontSize>(environment.content[0])
+
+        assertEquals(LatexNode.FontSize.SizeType.SMALL, fontSize.sizeType)
+        val content = assertIs<LatexNode.Text>(fontSize.content[0])
+        assertEquals("x", content.content)
+    }
+
+    @Test
+    fun testFontSizeDeclarationInMatrixCell() {
+        val doc = parser.parse("\\begin{matrix}\\small x & y\\end{matrix}")
+        val matrix = assertIs<LatexNode.Matrix>(doc.children[0])
+        val firstCell = assertIs<LatexNode.Group>(matrix.rows[0][0])
+        val fontSize = assertIs<LatexNode.FontSize>(firstCell.children[0])
+
+        assertEquals(LatexNode.FontSize.SizeType.SMALL, fontSize.sizeType)
+        val content = assertIs<LatexNode.Group>(fontSize.content[0])
+        assertEquals("x", (content.children[0] as LatexNode.Text).content)
+    }
+
+    @Test
+    fun testFontSizeDeclarationInCasesExpression() {
+        val doc = parser.parse("\\begin{cases}\\small x & x > 0\\end{cases}")
+        val cases = assertIs<LatexNode.Cases>(doc.children[0])
+        val expression = assertIs<LatexNode.Group>(cases.cases[0].first)
+        val fontSize = assertIs<LatexNode.FontSize>(expression.children[0])
+
+        assertEquals(LatexNode.FontSize.SizeType.SMALL, fontSize.sizeType)
+        val content = assertIs<LatexNode.Group>(fontSize.content[0])
+        assertEquals("x", (content.children[0] as LatexNode.Text).content)
+    }
 }

--- a/latex-parser/src/commonTest/kotlin/com/hrm/latex/parser/FontSizeTest.kt
+++ b/latex-parser/src/commonTest/kotlin/com/hrm/latex/parser/FontSizeTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 huarangmeng
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.hrm.latex.parser
+
+import com.hrm.latex.parser.model.LatexNode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class FontSizeTest {
+    private val parser = LatexParser()
+
+    @Test
+    fun testAllFontSizeCommands() {
+        val input = "\\tiny a \\scriptsize b \\footnotesize c \\small d \\normalsize e " +
+            "\\large f \\Large g \\LARGE h \\huge i \\Huge j"
+        val doc = parser.parse(input)
+
+        val sizes = doc.children.filterIsInstance<LatexNode.FontSize>().map { it.sizeType }
+
+        assertEquals(
+            listOf(
+                LatexNode.FontSize.SizeType.TINY,
+                LatexNode.FontSize.SizeType.SCRIPT_SIZE,
+                LatexNode.FontSize.SizeType.FOOTNOTE_SIZE,
+                LatexNode.FontSize.SizeType.SMALL,
+                LatexNode.FontSize.SizeType.NORMAL_SIZE,
+                LatexNode.FontSize.SizeType.LARGE,
+                LatexNode.FontSize.SizeType.LARGE_2,
+                LatexNode.FontSize.SizeType.LARGE_3,
+                LatexNode.FontSize.SizeType.HUGE,
+                LatexNode.FontSize.SizeType.HUGE_2,
+            ),
+            sizes
+        )
+    }
+
+    @Test
+    fun testFontSizeDeclarationScopesToFollowingGroupContent() {
+        val doc = parser.parse("{\\small x + y}")
+        val group = assertIs<LatexNode.Group>(doc.children[0])
+        val fontSize = assertIs<LatexNode.FontSize>(group.children[0])
+
+        assertEquals(LatexNode.FontSize.SizeType.SMALL, fontSize.sizeType)
+        assertTrue(fontSize.content.isNotEmpty())
+        assertEquals("x", (fontSize.content[0] as LatexNode.Text).content)
+    }
+
+    @Test
+    fun testExplicitGroupArgument() {
+        val doc = parser.parse("\\Huge{x + y}")
+        val fontSize = assertIs<LatexNode.FontSize>(doc.children[0])
+
+        assertEquals(LatexNode.FontSize.SizeType.HUGE_2, fontSize.sizeType)
+        assertIs<LatexNode.Group>(fontSize.content[0])
+    }
+}

--- a/latex-parser/src/commonTest/kotlin/com/hrm/latex/parser/FontSizeTest.kt
+++ b/latex-parser/src/commonTest/kotlin/com/hrm/latex/parser/FontSizeTest.kt
@@ -64,7 +64,8 @@ class FontSizeTest {
 
         assertEquals(LatexNode.FontSize.SizeType.SMALL, fontSize.sizeType)
         assertTrue(fontSize.content.isNotEmpty())
-        assertEquals("x", (fontSize.content[0] as LatexNode.Text).content)
+        val content = assertIs<LatexNode.Group>(fontSize.content[0])
+        assertEquals("x", (content.children[0] as LatexNode.Text).content)
     }
 
     @Test
@@ -74,5 +75,31 @@ class FontSizeTest {
 
         assertEquals(LatexNode.FontSize.SizeType.HUGE_2, fontSize.sizeType)
         assertIs<LatexNode.Group>(fontSize.content[0])
+    }
+
+    @Test
+    fun testBracedContentDoesNotEndDeclarationScope() {
+        val doc = parser.parse("{\\small{x} y}")
+        val group = assertIs<LatexNode.Group>(doc.children[0])
+        val fontSize = assertIs<LatexNode.FontSize>(group.children[0])
+        val content = assertIs<LatexNode.Group>(fontSize.content[0])
+
+        assertEquals(LatexNode.FontSize.SizeType.SMALL, fontSize.sizeType)
+        assertEquals(3, content.children.size)
+        assertIs<LatexNode.Group>(content.children[0])
+        assertEquals("y", (content.children[2] as LatexNode.Text).content)
+    }
+
+    @Test
+    fun testFontSizeSourceRangeCoversScopedContent() {
+        val input = "{\\small x + y}"
+        val doc = parser.parse(input)
+        val group = assertIs<LatexNode.Group>(doc.children[0])
+        val fontSize = assertIs<LatexNode.FontSize>(group.children[0])
+        val range = fontSize.sourceRange
+
+        assertTrue(range != null)
+        assertEquals(1, range.start)
+        assertEquals(input.length - 1, range.end)
     }
 }

--- a/latex-parser/src/commonTest/kotlin/com/hrm/latex/parser/MathMLVisitorTest.kt
+++ b/latex-parser/src/commonTest/kotlin/com/hrm/latex/parser/MathMLVisitorTest.kt
@@ -323,4 +323,14 @@ class MathMLVisitorTest {
         val result = MathMLVisitor.convert(doc)
         assertTrue(result.contains("<menclose"))
     }
+
+    @Test
+    fun testNestedFontSizeUsesAbsoluteDeclarationScale() {
+        val doc = parser.parse("{\\small {\\Huge x} {\\normalsize y}}")
+        val result = MathMLVisitor.convert(doc)
+
+        assertTrue(result.contains("mathsize=\"90%\""), result)
+        assertTrue(result.contains("mathsize=\"276.444%\""), result)
+        assertTrue(result.contains("mathsize=\"111.111%\""), result)
+    }
 }

--- a/latex-parser/src/commonTest/kotlin/com/hrm/latex/parser/MathStyleTest.kt
+++ b/latex-parser/src/commonTest/kotlin/com/hrm/latex/parser/MathStyleTest.kt
@@ -97,6 +97,16 @@ class MathStyleTest {
     }
 
     @Test
+    fun testMathStyleDeclarationInEnvironmentContent() {
+        val doc = parser.parse("\\begin{equation}\\displaystyle x\\end{equation}")
+        val env = doc.children[0] as LatexNode.Environment
+        val mathStyle = env.content[0] as LatexNode.MathStyle
+
+        assertEquals(LatexNode.MathStyle.MathStyleType.DISPLAY, mathStyle.mathStyleType)
+        assertEquals("x", (mathStyle.content[0] as LatexNode.Text).content)
+    }
+
+    @Test
     fun testMathStyleInSum() {
         // \sum_{\scriptstyle i=1}^{\scriptstyle n}
         val doc = parser.parse("\\sum_{\\scriptstyle i=1}^{\\scriptstyle n}")

--- a/latex-preview/src/commonMain/kotlin/com/hrm/latex/preview/BasicLatexPreview.kt
+++ b/latex-preview/src/commonMain/kotlin/com/hrm/latex/preview/BasicLatexPreview.kt
@@ -152,6 +152,8 @@ val basicLatexPreviewGroups = listOf(
             PreviewItem("11", "mathop + limits", "\\[\\int_0^\\infty  {1 - \\mathop \\prod \\limits_{i = 1}^n \\left( {1 - {e^{ - {p_i}t}}} \\right){\\text{d}}t} \\]"),
             PreviewItem("12", "Bbb (mathbb 别名)", "\\Bbb{R} \\quad \\mathbb{R} \\quad \\Bbb R"),
             PreviewItem("13", "cal/frak/scr (legacy)", "\\cal A \\quad \\frak g \\quad \\scr F"),
+            PreviewItem("14", "字号阶梯", "\\tiny x \\scriptsize x \\footnotesize x \\small x \\normalsize x \\large x \\Large x \\LARGE x \\huge x \\Huge x"),
+            PreviewItem("15", "字号作用域", "{\\small a + b} \\quad {\\Huge c + d}"),
         )
     ),
     PreviewGroup(

--- a/latex-renderer/src/commonMain/kotlin/com/hrm/latex/renderer/layout/HighlightCalculator.kt
+++ b/latex-renderer/src/commonMain/kotlin/com/hrm/latex/renderer/layout/HighlightCalculator.kt
@@ -176,6 +176,7 @@ internal object HighlightCalculator {
 
             is LatexNode.Style -> node.content.any { nodeContainsText(it, pattern) }
             is LatexNode.Color -> node.content.any { nodeContainsText(it, pattern) }
+            is LatexNode.FontSize -> node.content.any { nodeContainsText(it, pattern) }
             else -> false
         }
     }

--- a/latex-renderer/src/commonMain/kotlin/com/hrm/latex/renderer/layout/LatexMeasurer.kt
+++ b/latex-renderer/src/commonMain/kotlin/com/hrm/latex/renderer/layout/LatexMeasurer.kt
@@ -50,6 +50,7 @@ import com.hrm.latex.renderer.layout.measurer.TextContentMeasurer
 import com.hrm.latex.renderer.model.MathStyle
 import com.hrm.latex.renderer.model.RenderContext
 import com.hrm.latex.renderer.model.TextDirection
+import com.hrm.latex.renderer.model.applyFontSize
 import com.hrm.latex.renderer.model.applyMathStyle
 import com.hrm.latex.renderer.model.applyStyle
 import com.hrm.latex.renderer.model.textStyle
@@ -177,6 +178,10 @@ internal fun measureNode(
 
         is LatexNode.MathStyle -> measureGroup(
             node.content, context.applyMathStyle(node.mathStyleType), measurer, density, cache = cache
+        )
+
+        is LatexNode.FontSize -> measureGroup(
+            node.content, context.applyFontSize(node.sizeType), measurer, density, cache = cache
         )
 
         is LatexNode.Environment -> {

--- a/latex-renderer/src/commonMain/kotlin/com/hrm/latex/renderer/layout/LineBreaker.kt
+++ b/latex-renderer/src/commonMain/kotlin/com/hrm/latex/renderer/layout/LineBreaker.kt
@@ -159,7 +159,8 @@ internal class LineBreaker(private val maxWidth: Float) {
             is LatexNode.Delimited,
             is LatexNode.Style,
             is LatexNode.Color,
-            is LatexNode.MathStyle -> 1
+            is LatexNode.MathStyle,
+            is LatexNode.FontSize -> 1
 
             else -> 0
         }

--- a/latex-renderer/src/commonMain/kotlin/com/hrm/latex/renderer/model/RenderStyle.kt
+++ b/latex-renderer/src/commonMain/kotlin/com/hrm/latex/renderer/model/RenderStyle.kt
@@ -254,6 +254,7 @@ internal data class LayoutHints(
 internal data class RenderContext(
     // ── 样式状态 ──
     val fontSize: TextUnit,
+    val baseFontSize: TextUnit = fontSize,
     val color: Color,
     val errorColor: Color = Color(0xFFCC0000),
     val mathStyle: MathStyle = MathStyle.DISPLAY,
@@ -317,6 +318,7 @@ internal fun LatexConfig.toContext(
 
     return RenderContext(
         fontSize = fontSize,
+        baseFontSize = fontSize,
         color = resolvedColor,
         errorColor = resolvedErrorColor,
         fontFamily = fontFamilies.main,
@@ -470,5 +472,5 @@ internal fun RenderContext.applyFontSize(sizeType: LatexNode.FontSize.SizeType):
         LatexNode.FontSize.SizeType.HUGE -> 2.074f
         LatexNode.FontSize.SizeType.HUGE_2 -> 2.488f
     }
-    return copy(fontSize = fontSize * scale)
+    return copy(fontSize = baseFontSize * scale * mathStyle.scaleFactor())
 }

--- a/latex-renderer/src/commonMain/kotlin/com/hrm/latex/renderer/model/RenderStyle.kt
+++ b/latex-renderer/src/commonMain/kotlin/com/hrm/latex/renderer/model/RenderStyle.kt
@@ -456,3 +456,19 @@ internal fun RenderContext.applyMathStyle(mathStyleType: LatexNode.MathStyle.Mat
         mathStyle = newMode
     )
 }
+
+internal fun RenderContext.applyFontSize(sizeType: LatexNode.FontSize.SizeType): RenderContext {
+    val scale = when (sizeType) {
+        LatexNode.FontSize.SizeType.TINY -> 0.5f
+        LatexNode.FontSize.SizeType.SCRIPT_SIZE -> 0.7f
+        LatexNode.FontSize.SizeType.FOOTNOTE_SIZE -> 0.8f
+        LatexNode.FontSize.SizeType.SMALL -> 0.9f
+        LatexNode.FontSize.SizeType.NORMAL_SIZE -> 1.0f
+        LatexNode.FontSize.SizeType.LARGE -> 1.2f
+        LatexNode.FontSize.SizeType.LARGE_2 -> 1.44f
+        LatexNode.FontSize.SizeType.LARGE_3 -> 1.728f
+        LatexNode.FontSize.SizeType.HUGE -> 2.074f
+        LatexNode.FontSize.SizeType.HUGE_2 -> 2.488f
+    }
+    return copy(fontSize = fontSize * scale)
+}

--- a/latex-renderer/src/commonTest/kotlin/com/hrm/latex/renderer/model/RenderStyleFontSizeTest.kt
+++ b/latex-renderer/src/commonTest/kotlin/com/hrm/latex/renderer/model/RenderStyleFontSizeTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 huarangmeng
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.hrm.latex.renderer.model
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.sp
+import com.hrm.latex.parser.model.LatexNode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RenderStyleFontSizeTest {
+    @Test
+    fun fontSizeDeclarationUsesBaseFontSizeInsteadOfCurrentFontSize() {
+        val context = RenderContext(
+            fontSize = 20.sp,
+            baseFontSize = 20.sp,
+            color = Color.Black
+        )
+
+        val small = context.applyFontSize(LatexNode.FontSize.SizeType.SMALL)
+        val hugeInsideSmall = small.applyFontSize(LatexNode.FontSize.SizeType.HUGE_2)
+
+        assertEquals(18f, small.fontSize.value, 0.001f)
+        assertEquals(49.76f, hugeInsideSmall.fontSize.value, 0.001f)
+    }
+}


### PR DESCRIPTION
支持一大堆字号指令。

<img width="574" height="564" alt="7366ab1f924d6bfc29c389a19ee72bd0" src="https://github.com/user-attachments/assets/e277033e-4ff5-4971-8ec1-efba6678fb69" />

关于declaration:

`\mathbf`, `\small`等都是declaration。比如`{\small{x} + y}`应该应用到整个group。在本PR中，顺带修复。